### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Coverage
 
 Latests PyPI Release
 --------------------
-.. image:: https://pypip.in/v/onegov.server/badge.png
+.. image:: https://img.shields.io/pypi/v/onegov.server.svg
   :target: https://crate.io/packages/onegov.server
   :alt: Latest PyPI Release
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20onegov-server))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `onegov-server`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.